### PR TITLE
Implemented anti-aliasing with toggle checkbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.vs
+.vs/*
+/build
+/build/*
+/build/**/*
+/out
+/out/*
+/out/**/*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,8 +142,8 @@ void showGui(Context &ctx)
         rt::resetAccumulation(ctx.rtx);
     }
     if (ImGui::Checkbox("Show normals", &ctx.rtx.show_normals)) { rt::resetAccumulation(ctx.rtx); }
-    // Add more settings and parameters here
-    // ...
+
+    if (ImGui::Checkbox("Use anti-aliasing", &ctx.rtx.use_anti_aliasing)) { rt::resetAccumulation(ctx.rtx); }
 
     ImGui::Text("Progress");
     ImGui::ProgressBar(float(ctx.rtx.current_frame) / ctx.rtx.max_frames);

--- a/src/rt_raytracing.cpp
+++ b/src/rt_raytracing.cpp
@@ -127,8 +127,13 @@ void updateLine(RTContext &rtx, int y)
     // You can try parallelising this loop by uncommenting this line:
     //#pragma omp parallel for schedule(dynamic)
     for (int x = 0; x < nx; ++x) {
-        float u = (float(x) + 0.5f) / float(nx);
-        float v = (float(y) + 0.5f) / float(ny);
+
+        float u_offset = rtx.use_anti_aliasing ? rt::random_double() : 0.5f;
+        float v_offset = rtx.use_anti_aliasing ? rt::random_double() : 0.5f;
+
+        float u = (float(x) + u_offset) / float(nx);
+        float v = (float(y) + v_offset) / float(ny);
+
         Ray r(origin, lower_left_corner + u * horizontal + v * vertical);
         r.A = glm::vec3(world_from_view * glm::vec4(r.A, 1.0f));
         r.B = glm::vec3(world_from_view * glm::vec4(r.B, 0.0f));

--- a/src/rt_raytracing.h
+++ b/src/rt_raytracing.h
@@ -5,6 +5,7 @@
 #include <glm/gtc/matrix_transform.hpp>
 
 #include <vector>
+#include <random>
 
 namespace rt {
 
@@ -24,11 +25,18 @@ struct RTContext {
     bool show_normals = true;
     // Add more settings and parameters here
     // ...
+    bool use_anti_aliasing = true;
 };
 
 void setupScene(RTContext &rtx, const char *mesh_filename);
 void updateImage(RTContext &rtx);
 void resetImage(RTContext &rtx);
 void resetAccumulation(RTContext &rtx);
+
+inline double random_double() {
+    static std::uniform_real_distribution<double> distribution(0.0, 1.0);
+    static std::mt19937 generator;
+    return distribution(generator);
+}
 
 }  // namespace rt


### PR DESCRIPTION
This PR also includes a `random_double` function in `rt_raytracing.h` that returns a random double between 0.0 and 1.0.

Without anti-aliasing:
![rt_1](https://user-images.githubusercontent.com/21147276/221541271-40edd850-16b4-4823-ad46-a9f82b95a51b.png)

With anti-aliasing:
![rt_2](https://user-images.githubusercontent.com/21147276/221541260-4b7997cd-b286-45c7-9ae6-5a97ae920bbb.png)

Checkbox toggle:
![rt_3](https://user-images.githubusercontent.com/21147276/221541268-60fcce1e-b129-4e2b-818d-eb466ce75413.png)
